### PR TITLE
Exclude public endpoints from JwtFilter

### DIFF
--- a/src/main/java/com/example/iTravel/controller/UserController.java
+++ b/src/main/java/com/example/iTravel/controller/UserController.java
@@ -2,6 +2,7 @@ package com.example.iTravel.controller;
 
 import com.example.iTravel.model.POI;
 import com.example.iTravel.model.TravelGuide;
+import com.example.iTravel.model.User;
 import com.example.iTravel.service.UserService;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
@@ -25,4 +26,5 @@ public class UserController {
     public List<POI> getUserPOIs(@PathVariable String userId) {
         return userService.getUserPOIs(userId);
     }
+
 }

--- a/src/main/java/com/example/iTravel/filters/JwtFilter.java
+++ b/src/main/java/com/example/iTravel/filters/JwtFilter.java
@@ -15,8 +15,12 @@ import jakarta.servlet.ServletResponse;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import javax.print.attribute.standard.DialogOwner;
 import java.io.IOException;
 import java.security.Key;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
 
 @Component
 public class JwtFilter implements Filter {
@@ -36,11 +40,15 @@ public class JwtFilter implements Filter {
         HttpServletRequest httpRequest = (HttpServletRequest) request;
         String path = httpRequest.getRequestURI();
 
-        if (path.startsWith("/api/auth/signup") || path.startsWith("/api/auth/login")) {
+        // 公开路径
+        Set<String> openPaths = new HashSet<>(Arrays.asList(PublicPaths.PATHS));
+
+        if (openPaths.stream().anyMatch(path::startsWith)) {
             chain.doFilter(request, response);
             return;
         }
 
+        //需验证路径
         String authorizationHeader = httpRequest.getHeader("Authorization");
 
         if (authorizationHeader == null || !authorizationHeader.startsWith("Bearer ")) {

--- a/src/main/java/com/example/iTravel/filters/PublicPaths.java
+++ b/src/main/java/com/example/iTravel/filters/PublicPaths.java
@@ -1,0 +1,22 @@
+package com.example.iTravel.filters;
+
+/**
+ * ClassName: PublicPaths
+ * Package: com.example.iTravel.filters
+ * Description:
+ *
+ * @Author Yuki
+ * @Create 15/08/2024 10:45
+ * @Version 1.0
+ */
+public class PublicPaths {
+    public static final String[] PATHS = {
+            "/",
+            "/home",
+            "/guide",
+            "/preferences",
+            "/recommendations",
+            "/auth/",
+            "/download_avatar/"
+    };
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -2,8 +2,7 @@ spring.application.name=iTravel
 
 spring.data.mongodb.uri=mongodb+srv://ariachen1014:yukikefan@cluster0.q6o9mbw.mongodb.net/iTravelDB?retryWrites=true&w=majority&appName=Cluster0
 
-# ??????????????????????????
-# spring.data.mongodb.database=test
+#spring.data.mongodb.database=test
 
 kimi.api.url=https://kimi-free-api-nut5.onrender.com/v1/chat/completions
 

--- a/unified-frontend/src/AuthContext.js
+++ b/unified-frontend/src/AuthContext.js
@@ -13,16 +13,16 @@ export const AuthProvider = ({ children }) => {
       const token = localStorage.getItem('token');
       if (token) {
         try {
-          // 修改: 使用 await 等待认证检查完成
           const response = await axios.get('http://localhost:8080/api/auth/me', {
             headers: {
               Authorization: `Bearer ${token}`
             }
           });
+          console.log("User data fetched:", response.data); // 调试信息
           setUser(response.data);
         } catch (error) {
           console.error('Auth check failed:', error);
-          // 修改: 清除 token 和用户信息
+  
           localStorage.removeItem('token');
           localStorage.removeItem('user');
         }
@@ -67,7 +67,7 @@ export const AuthProvider = ({ children }) => {
 
   const updateUser = (updatedUser) => {
     setUser(updatedUser);
-    // 修改: 移除更新本地存储的用户信息
+    localStorage.setItem('user', JSON.stringify(updatedUser)); // Ensure the updated user data is stored
   };
 
   // 修改: 在 context value 中包含 loading 状态

--- a/unified-frontend/src/UserAvatar.js
+++ b/unified-frontend/src/UserAvatar.js
@@ -58,8 +58,8 @@ const UserAvatar = () => {
     const file = event.target.files[0];
     if (file && file.type.startsWith('image/')) {
       const objectUrl = URL.createObjectURL(file);
-      setAvatarPreview(objectUrl);
-      handleFileUpload(file);
+      setAvatarPreview(objectUrl);//临时URL用于预览
+      handleFileUpload(file);//上传，成功后持久化URL
       return () => URL.revokeObjectURL(objectUrl);
     }
   };


### PR DESCRIPTION
Because of JwtFilter and WebSecurityConfig Conflict, refactored JwtFilter to exclude public endpoints from JWT authentication. Todo: Move endpoint exclusions to WebSecurityConfig for clarity.